### PR TITLE
Use colorable for Windows output

### DIFF
--- a/blame.go
+++ b/blame.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
+	"github.com/wttw/wowaddon/output"
 )
 
 func blame(c *cli.Context) error {

--- a/blame.go
+++ b/blame.go
@@ -1,8 +1,7 @@
 package main
 
 import (
-	"fmt"
-
+	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
 )
 
@@ -15,7 +14,7 @@ func blame(c *cli.Context) error {
 		for _, dir := range meta.Folders {
 			_, ok := dirs[dir]
 			if ok {
-				fmt.Printf("%s: %s\n", dir, name)
+				output.Printf("%s: %s\n", dir, name)
 			}
 		}
 	}

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -4,8 +4,8 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
+	"github.com/wttw/wowaddon/output"
 )
 
 func bootstrap(c *cli.Context) error {

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"io/ioutil"
 	"strings"
 
+	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
 )
 
@@ -32,12 +32,12 @@ func bootstrapConfig() error {
 		if strings.HasPrefix(f.Name(), ".") {
 			continue
 		}
-		// fmt.Printf("dir %s found\n", f.Name())
+		// output.Printf("dir %s found\n", f.Name())
 		dirs[f.Name()] = false
 	}
 
 	for _, source := range catalog.Preference {
-		// fmt.Printf("catalog source: %s\n", source)
+		// output.Printf("catalog source: %s\n", source)
 		for name, addon := range catalog.Sources[source].Addons {
 			if len(addon.Folder) == 0 {
 				continue
@@ -45,7 +45,7 @@ func bootstrapConfig() error {
 			possible := true
 			someunused := false
 			for _, dir := range addon.Folder {
-				// fmt.Printf("Checking for %s\n", dir)
+				// output.Printf("Checking for %s\n", dir)
 				used, ok := dirs[dir]
 				if !ok {
 					possible = false
@@ -57,9 +57,9 @@ func bootstrapConfig() error {
 			}
 			if possible {
 				if !someunused {
-					fmt.Printf("Multiple addons (%s) use directories %s - check configuration\n", name, strings.Join(addon.Folder, ", "))
+					output.Printf("Multiple addons (%s) use directories %s - check configuration\n", name, strings.Join(addon.Folder, ", "))
 				} else {
-					// fmt.Printf("Found addon %s\n", name)
+					// output.Printf("Found addon %s\n", name)
 					config.Addons[name] = Addon{
 						Source:  source,
 						Folders: addon.Folder,
@@ -77,6 +77,6 @@ func bootstrapConfig() error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("%s\n", success("Configuration created"))
+	output.Printf("%s\n", success("Configuration created"))
 	return nil
 }

--- a/catalog.go
+++ b/catalog.go
@@ -4,7 +4,7 @@ import (
 	"archive/zip"
 	"encoding/json"
 	"fmt"
-	"github.com/pdbogen/wowaddon/output"
+	"github.com/wttw/wowaddon/output"
 	"io"
 	"io/ioutil"
 	"net/http"

--- a/catalog.go
+++ b/catalog.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"encoding/json"
 	"fmt"
+	"github.com/pdbogen/wowaddon/output"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -45,15 +46,15 @@ func loadCatalogFromJSON() error {
 		jsonParser := json.NewDecoder(file)
 		err = jsonParser.Decode(&catalog)
 		if err != nil {
-			fmt.Printf("I couldn't parse catalog file '%s': %s\nMaybe fix it up, or delete it and start over?\n", configFile, err.Error())
+			output.Printf("I couldn't parse catalog file '%s': %s\nMaybe fix it up, or delete it and start over?\n", configFile, err.Error())
 			os.Exit(1)
 		}
 		if catalog.Abort != "" {
-			fmt.Printf("%s\n", failed(catalog.Abort))
+			output.Printf("%s\n", failed(catalog.Abort))
 			os.Exit(1)
 		}
 		if catalog.Version > numericVersion {
-			fmt.Printf("%s: There is an update to wowaddon available\nSee https://github.com/wttw/wowaddon/releases/latest\n", warn("Out of date"))
+			output.Printf("%s: There is an update to wowaddon available\nSee https://github.com/wttw/wowaddon/releases/latest\n", warn("Out of date"))
 		}
 		return nil
 	}
@@ -75,24 +76,24 @@ func loadCatalogFromZip() error {
 			}
 			of, err := os.OpenFile(catalogFile, os.O_WRONLY|os.O_CREATE, 0644)
 			if err != nil {
-				fmt.Printf("Couldn't create catalog file %s: %s\n", catalogFile, err.Error())
+				output.Printf("Couldn't create catalog file %s: %s\n", catalogFile, err.Error())
 				os.Exit(1)
 			}
 			_, err = io.Copy(of, rc)
 			if err != nil {
-				fmt.Printf("Couldn't create catalog file %s: %s\n", catalogFile, err.Error())
+				output.Printf("Couldn't create catalog file %s: %s\n", catalogFile, err.Error())
 				os.Exit(1)
 			}
 			err = of.Close()
 			if err != nil {
-				fmt.Printf("Couldn't create catalog file %s: %s\n", catalogFile, err.Error())
+				output.Printf("Couldn't create catalog file %s: %s\n", catalogFile, err.Error())
 				os.Exit(1)
 			}
 			config.CatalogDownloaded = time.Now()
 			config.NextCatalogUpdate = time.Now().Add(6 * time.Hour)
 			err = writeConfig()
 			if err != nil {
-				fmt.Printf("Failed to save configuration: %s\n", err.Error())
+				output.Printf("Failed to save configuration: %s\n", err.Error())
 				os.Exit(1)
 			}
 			err = loadCatalogFromJSON()
@@ -110,14 +111,14 @@ func loadCatalogFromZip() error {
 			// 	for name, data := range catalog.Sources[source].Addons {
 			// 		err = index.Index(name, data)
 			// 		if err != nil {
-			// 			fmt.Printf("Problem indexing '%+v': %s\n", data, err.Error())
+			// 			output.Printf("Problem indexing '%+v': %s\n", data, err.Error())
 			// 		}
 			// 	}
 			// }
 
 			// err = index.Close()
 			// if err != nil {
-			// 	fmt.Printf("Problem creating index: %s\n", err.Error())
+			// 	output.Printf("Problem creating index: %s\n", err.Error())
 			// }
 
 			return nil
@@ -151,8 +152,8 @@ func fetchCatalog(current time.Time) error {
 		return fmt.Errorf("No assets found in response")
 	}
 
-	// fmt.Printf("%T\n", assetsmap)
-	// fmt.Printf("%+v\n", assetsmap)
+	// output.Printf("%T\n", assetsmap)
+	// output.Printf("%+v\n", assetsmap)
 	assets, ok := assetsmap.([]interface{})
 	if !ok {
 		return fmt.Errorf("Couldn't decode assets")
@@ -177,7 +178,7 @@ func fetchCatalog(current time.Time) error {
 			// not stale
 			return nil
 		}
-		fmt.Printf("Fetching catalog from %s\n", dlurl)
+		output.Printf("Fetching catalog from %s\n", dlurl)
 		resp, err := Get(dlurl)
 		if err != nil {
 			return err
@@ -217,12 +218,12 @@ func loadCatalog() error {
 		if err != nil {
 			err = fetchCatalog(time.Unix(0, 0))
 			if err != nil {
-				fmt.Printf("Failed to fetch catalog: %s\n", err.Error())
+				output.Printf("Failed to fetch catalog: %s\n", err.Error())
 				os.Exit(1)
 			}
 			err = loadCatalogFromZip()
 			if err != nil {
-				fmt.Printf("Failed to load catalog just fetched: %s\n", err.Error())
+				output.Printf("Failed to load catalog just fetched: %s\n", err.Error())
 				os.Exit(1)
 			}
 		}
@@ -230,12 +231,12 @@ func loadCatalog() error {
 	if config.NextCatalogUpdate.Before(time.Now()) {
 		err = fetchCatalog(config.CatalogDownloaded)
 		if err != nil {
-			fmt.Printf("Failed to fetch catalog: %s\n", err.Error())
+			output.Printf("Failed to fetch catalog: %s\n", err.Error())
 			os.Exit(1)
 		}
 		err = loadCatalogFromZip()
 		if err != nil {
-			fmt.Printf("Failed to load catalog just fetched: %s\n", err.Error())
+			output.Printf("Failed to load catalog just fetched: %s\n", err.Error())
 			os.Exit(1)
 		}
 	}

--- a/dlurl.go
+++ b/dlurl.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
+	"github.com/wttw/wowaddon/output"
 )
 
 func dlurl(c *cli.Context) error {

--- a/dlurl.go
+++ b/dlurl.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
 )
 
@@ -13,9 +14,9 @@ func dlurl(c *cli.Context) error {
 	for _, name := range c.Args() {
 		meta, err := downloadURL(name, addonSource)
 		if err != nil {
-			fmt.Printf("%s: %s\n", name, err.Error())
+			output.Printf("%s: %s\n", name, err.Error())
 		} else {
-			fmt.Printf("%s: %d %s\n", name, meta.Version, meta.URL)
+			output.Printf("%s: %d %s\n", name, meta.Version, meta.URL)
 		}
 	}
 	return nil

--- a/environment.go
+++ b/environment.go
@@ -1,29 +1,29 @@
 package main
 
 import (
-	"fmt"
 	"runtime"
 
+	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
 )
 
 func environment(c *cli.Context) error {
-	fmt.Printf("%s version:     %s %s/%s\n", c.App.Name, c.App.Version, runtime.GOOS, runtime.GOARCH)
-	fmt.Printf("Configuration:        %s\n", configFile)
-	fmt.Printf("WoW directory:        %s\n", wowDir)
-	fmt.Printf("Catalog:              %s\n", catalogFile)
-	fmt.Printf("Catalog fetched:      %s\n", config.CatalogDownloaded)
-	fmt.Printf("Next catalog refresh: %s\n", config.NextCatalogUpdate)
-	fmt.Printf("Cache directory:      %s\n", cacheDir)
+	output.Printf("%s version:     %s %s/%s\n", c.App.Name, c.App.Version, runtime.GOOS, runtime.GOARCH)
+	output.Printf("Configuration:        %s\n", configFile)
+	output.Printf("WoW directory:        %s\n", wowDir)
+	output.Printf("Catalog:              %s\n", catalogFile)
+	output.Printf("Catalog fetched:      %s\n", config.CatalogDownloaded)
+	output.Printf("Next catalog refresh: %s\n", config.NextCatalogUpdate)
+	output.Printf("Cache directory:      %s\n", cacheDir)
 	cf, err := readWowConfig()
 	if err != nil {
-		fmt.Printf("Interface version:    (failed to read configuration)\n")
+		output.Printf("Interface version:    (failed to read configuration)\n")
 	} else {
 		version, ok := cf["lastAddonVersion"]
 		if !ok {
-			fmt.Printf("Interface version:    (not found)\n")
+			output.Printf("Interface version:    (not found)\n")
 		} else {
-			fmt.Printf("Interface version:    %s\n", version)
+			output.Printf("Interface version:    %s\n", version)
 		}
 	}
 	return nil

--- a/environment.go
+++ b/environment.go
@@ -3,8 +3,8 @@ package main
 import (
 	"runtime"
 
-	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
+	"github.com/wttw/wowaddon/output"
 )
 
 func environment(c *cli.Context) error {

--- a/install.go
+++ b/install.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
+	"github.com/wttw/wowaddon/output"
 )
 
 func installFromMeta(meta AddonMeta) (Addon, error) {

--- a/install.go
+++ b/install.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
 )
 
@@ -124,7 +125,7 @@ func populateVersion(name string) {
 func installAddon(name string, source string, verb string) error {
 	meta, err := downloadURL(name, source)
 	if err != nil {
-		fmt.Printf("%s: failed: %s\n", failed(name), err.Error())
+		output.Printf("%s: failed: %s\n", failed(name), err.Error())
 	} else {
 		ao, err := installFromMeta(meta)
 
@@ -134,11 +135,11 @@ func installAddon(name string, source string, verb string) error {
 
 			err = writeConfig()
 			if err != nil {
-				fmt.Printf("%s: failed to write configuration file '%s': %s\n", failed(name), configFile, err.Error())
+				output.Printf("%s: failed to write configuration file '%s': %s\n", failed(name), configFile, err.Error())
 				return err
 			}
 		} else {
-			fmt.Printf("%s: failed: %s\n", failed(name), err.Error())
+			output.Printf("%s: failed: %s\n", failed(name), err.Error())
 		}
 	}
 	return nil
@@ -181,7 +182,7 @@ func purgeCache() {
 	}
 	cacheFiles, err := ioutil.ReadDir(cacheDir)
 	if err != nil {
-		fmt.Printf("Error reading cache directory: %s\n", err.Error())
+		output.Printf("Error reading cache directory: %s\n", err.Error())
 		return
 	}
 	for _, file := range cacheFiles {

--- a/list.go
+++ b/list.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"fmt"
 	"io/ioutil"
 	"strconv"
 	"strings"
 
+	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
 )
 
@@ -40,7 +40,7 @@ func list(c *cli.Context) error {
 		if strings.HasPrefix(f.Name(), ".") {
 			continue
 		}
-		// fmt.Printf("dir %s found\n", f.Name())
+		// output.Printf("dir %s found\n", f.Name())
 		dirs[f.Name()] = false
 	}
 
@@ -54,7 +54,7 @@ func list(c *cli.Context) error {
 			dirs[d] = true
 		}
 		if !installed {
-			fmt.Printf("%s: not installed\n", failed(name))
+			output.Printf("%s: not installed\n", failed(name))
 			continue
 		}
 		locked := ""
@@ -62,9 +62,9 @@ func list(c *cli.Context) error {
 			locked = "(locked) "
 		}
 		if wowV != 0 && addon.Interface != 0 && addon.Interface < wowV {
-			fmt.Printf("%s: %s(out of date) version %s installed\n", warn(name), locked, addon.Version)
+			output.Printf("%s: %s(out of date) version %s installed\n", warn(name), locked, addon.Version)
 		} else {
-			fmt.Printf("%s: %sversion %s installed\n", success(name), locked, addon.Version)
+			output.Printf("%s: %sversion %s installed\n", success(name), locked, addon.Version)
 		}
 	}
 	orphans := []string{}
@@ -74,7 +74,7 @@ func list(c *cli.Context) error {
 		}
 	}
 	if len(orphans) > 0 {
-		fmt.Printf("%s: %s\n", warn("Unmanaged addon directories"), strings.Join(orphans, ", "))
+		output.Printf("%s: %s\n", warn("Unmanaged addon directories"), strings.Join(orphans, ", "))
 	}
 	return nil
 }
@@ -89,19 +89,19 @@ func fullinfo(c *cli.Context) error {
 	for _, name := range addons {
 		addon, ok := config.Addons[name]
 		if !ok {
-			fmt.Printf("%s: not installed\n", failed(name))
+			output.Printf("%s: not installed\n", failed(name))
 			continue
 		}
-		fmt.Printf("%s: version %s\n", success(name), addon.Version)
+		output.Printf("%s: version %s\n", success(name), addon.Version)
 		for _, dir := range addon.Folders {
 			toc, err := readToc(dir)
 			if err != nil {
-				fmt.Printf("  %s: failed to read toc: %s\n", failed(dir), err.Error())
+				output.Printf("  %s: failed to read toc: %s\n", failed(dir), err.Error())
 				continue
 			}
-			fmt.Printf("  %s:\n", success(dir))
+			output.Printf("  %s:\n", success(dir))
 			for k, v := range toc {
-				fmt.Printf("    %s: %s\n", k, v)
+				output.Printf("    %s: %s\n", k, v)
 			}
 		}
 	}
@@ -118,31 +118,31 @@ func info(c *cli.Context) error {
 	for _, name := range addons {
 		addon, ok := config.Addons[name]
 		if !ok {
-			fmt.Printf("%s: not installed\n", failed(name))
+			output.Printf("%s: not installed\n", failed(name))
 			continue
 		}
-		fmt.Printf("%s: version %s\n", success(name), addon.Version)
+		output.Printf("%s: version %s\n", success(name), addon.Version)
 		for _, dir := range addon.Folders {
 
 			toc, err := readToc(dir)
 			if err != nil {
-				fmt.Printf("  %s: failed to read toc: %s\n", failed(dir), err.Error())
+				output.Printf("  %s: failed to read toc: %s\n", failed(dir), err.Error())
 				continue
 			}
 
-			fmt.Printf("  %s:", success(dir))
+			output.Printf("  %s:", success(dir))
 			ver, ok := toc["version"]
 			if ok {
-				fmt.Printf(" version: %s", ver)
+				output.Printf(" version: %s", ver)
 			}
 			iface, ok := toc["interface"]
 			if ok {
-				fmt.Printf(" compatible: %s", iface)
+				output.Printf(" compatible: %s", iface)
 			}
-			fmt.Printf("\n")
+			output.Printf("\n")
 			notes, ok := toc["notes"]
 			if ok {
-				fmt.Printf("    %s\n", notes)
+				output.Printf("    %s\n", notes)
 			}
 		}
 	}

--- a/list.go
+++ b/list.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
+	"github.com/wttw/wowaddon/output"
 )
 
 func wowVersion() int {

--- a/lock.go
+++ b/lock.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
 )
 
@@ -14,15 +15,15 @@ func lock(c *cli.Context) error {
 	for _, name := range addons {
 		addon, ok := config.Addons[name]
 		if !ok {
-			fmt.Printf("%s: isn't installed\n", failed(name))
+			output.Printf("%s: isn't installed\n", failed(name))
 			continue
 		}
 		if addon.Locked {
-			fmt.Printf("%s: already locked\n", warn(name))
+			output.Printf("%s: already locked\n", warn(name))
 		} else {
 			addon.Locked = true
 			config.Addons[name] = addon
-			fmt.Printf("%s: locked\n", success(name))
+			output.Printf("%s: locked\n", success(name))
 		}
 	}
 	return writeConfig()
@@ -43,15 +44,15 @@ func unlock(c *cli.Context) error {
 	for _, name := range addons {
 		addon, ok := config.Addons[name]
 		if !ok {
-			fmt.Printf("%s: isn't installed\n", failed(name))
+			output.Printf("%s: isn't installed\n", failed(name))
 			continue
 		}
 		if addon.Locked {
 			addon.Locked = false
 			config.Addons[name] = addon
-			fmt.Printf("%s: unlocked\n", success(name))
+			output.Printf("%s: unlocked\n", success(name))
 		} else {
-			fmt.Printf("%s: already unlocked\n", warn(name))
+			output.Printf("%s: already unlocked\n", warn(name))
 		}
 	}
 	return writeConfig()

--- a/lock.go
+++ b/lock.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
+	"github.com/wttw/wowaddon/output"
 )
 
 func lock(c *cli.Context) error {

--- a/os_nonwin.go
+++ b/os_nonwin.go
@@ -6,7 +6,3 @@ var installDirs = []string{
 	`/Applications/World of Warcraft`,
 	`/Users/Steve/World of Warcraft`,
 }
-
-func EnableColor() error {
-	return nil
-}

--- a/os_win.go
+++ b/os_win.go
@@ -2,52 +2,9 @@
 
 package main
 
-import (
-	"errors"
-	"fmt"
-	"os"
-	"syscall"
-)
-
 var installDirs = []string{
 	`C:\Program Files\World of Warcraft`,
 	`C:\Program Files (x86)\World of Warcraft`,
 	`C:\Users\Public\Games\World of Warcraft`,
 	`D:\Program Files\World of Warcraft`,
-}
-
-const (
-	enableProcessedOutput           uintptr = 0x01
-	enableVirtualTerminalProcessing         = 0x04
-)
-
-const (
-	errorInvalidHandle uintptr = 0x06
-)
-
-func EnableColor() error {
-	// This obtains a handle for the kernel32 DLL and then the SetConsoleMode function from that DLL. This function
-	// is described here: https://msdn.microsoft.com/en-us/library/windows/desktop/ms686033(v=vs.85).aspx
-	dll := syscall.MustLoadDLL("kernel32")
-	setConsoleMode := dll.MustFindProc("SetConsoleMode")
-	if os.Stdout == nil {
-		return errors.New("stdout is nil")
-	}
-	handle := syscall.Handle(os.Stdout.Fd())
-
-	// Call the obtained SetConsoleMode, setting ENABLE_PROCESSED_OUTPUT (was set anyway) and
-	// ENABLE_VIRTUAL_TERMINAL_PROCESSING (the important one)
-	r1, _, err := setConsoleMode.Call(uintptr(handle), uintptr(enableProcessedOutput|enableVirtualTerminalProcessing))
-	if r1 == 0 {
-		errNo := "(unknown)"
-		if en, ok := err.(syscall.Errno); ok {
-			if uintptr(en) == errorInvalidHandle {
-				return nil
-			}
-			errNo = fmt.Sprintf("%x", int(en))
-		}
-		return fmt.Errorf("setting console mode: %s -- %s", errNo, err)
-	}
-
-	return nil
 }

--- a/output/output_nonwin.go
+++ b/output/output_nonwin.go
@@ -3,9 +3,9 @@
 package output
 
 func Printf(format string, v ...interface{}) {
-	fmt.Printf(format, v)
+	fmt.Printf(format, v...)
 }
 
 func Print(v ...interface{}) {
-	fmt.Print(v)
+	fmt.Print(v...)
 }

--- a/output/output_nonwin.go
+++ b/output/output_nonwin.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package output
+
+func Printf(format string, v ...interface{}) {
+	fmt.Printf(format, v)
+}
+
+func Print(v ...interface{}) {
+	fmt.Print(v)
+}

--- a/output/output_win.go
+++ b/output/output_win.go
@@ -1,0 +1,22 @@
+// +build windows
+
+package output
+
+import (
+	"fmt"
+	"github.com/mattn/go-colorable"
+)
+
+func Printf(format string, v ...interface{}) {
+	if _, err := colorOut.Write([]byte(fmt.Sprintf(format, v...))); err != nil {
+		panic(err)
+	}
+}
+
+func Print(v ...interface{}) {
+	if _, err := colorOut.Write([]byte(fmt.Sprint(v...))); err != nil {
+		panic(err)
+	}
+}
+
+var colorOut = colorable.NewColorableStdout()

--- a/search.go
+++ b/search.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
+	"github.com/wttw/wowaddon/output"
 )
 
 var useRegex bool

--- a/search.go
+++ b/search.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"regexp"
 	"strings"
 
+	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
 )
 
@@ -15,7 +15,7 @@ func search(c *cli.Context) error {
 	wowV := wowVersion()
 
 	if len(c.Args()) == 0 {
-		fmt.Printf("You must provide a string to search for\n")
+		output.Printf("You must provide a string to search for\n")
 		os.Exit(1)
 	}
 	loadCatalog()
@@ -26,7 +26,7 @@ func search(c *cli.Context) error {
 		if useRegex {
 			_, err := regexp.Compile(w)
 			if err != nil {
-				fmt.Printf("%s: '%s' isn't a valid regex: %s\n", failed("Error"), w, err.Error())
+				output.Printf("%s: '%s' isn't a valid regex: %s\n", failed("Error"), w, err.Error())
 				os.Exit(1)
 			}
 			words = append(words, w)
@@ -39,7 +39,7 @@ func search(c *cli.Context) error {
 
 	re, err := regexp.Compile(pattern)
 	if err != nil {
-		fmt.Printf("%s: Failed to compile '%s': %s\n", failed("Internal Error"), pattern, err.Error())
+		output.Printf("%s: Failed to compile '%s': %s\n", failed("Internal Error"), pattern, err.Error())
 	}
 
 	for _, source := range catalog.Preference {
@@ -66,12 +66,12 @@ func search(c *cli.Context) error {
 			}
 			if namematch || titlematch || len(notes) > 0 {
 				if addon.Interface >= wowV {
-					fmt.Printf("%s: %s\n", success(name), addon.Title)
+					output.Printf("%s: %s\n", success(name), addon.Title)
 				} else {
-					fmt.Printf("%s: %s (out of date)\n", failed(name), addon.Title)
+					output.Printf("%s: %s (out of date)\n", failed(name), addon.Title)
 				}
 				for _, note := range notes {
-					fmt.Printf("  %s\n", note)
+					output.Printf("  %s\n", note)
 				}
 			}
 		}

--- a/sources.go
+++ b/sources.go
@@ -11,8 +11,8 @@ import (
 
 	"strings"
 
-	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
+	"github.com/wttw/wowaddon/output"
 )
 
 // AddonMeta holds the metadata for an addon

--- a/sources.go
+++ b/sources.go
@@ -11,6 +11,7 @@ import (
 
 	"strings"
 
+	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
 )
 
@@ -151,7 +152,7 @@ func getZipfile(name string, url string, source string) (string, error) {
 	if err == nil {
 		return zipfile, nil
 	}
-	fmt.Printf("%s: Fetching from %s\n", name, url)
+	output.Printf("%s: Fetching from %s\n", name, url)
 
 	tempfile, err := ioutil.TempFile(cacheDir, fmt.Sprintf("downloading-%s", name))
 	if err != nil {

--- a/uninstall.go
+++ b/uninstall.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
+	"github.com/wttw/wowaddon/output"
 )
 
 func uninstall(c *cli.Context) error {

--- a/uninstall.go
+++ b/uninstall.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
 )
 
@@ -12,7 +12,7 @@ func uninstall(c *cli.Context) error {
 	for _, name := range c.Args() {
 		addon, ok := config.Addons[name]
 		if !ok {
-			fmt.Printf("%s: %s: wasn't installed by me\n", name, failed("failed"))
+			output.Printf("%s: %s: wasn't installed by me\n", name, failed("failed"))
 		} else {
 			for _, d := range addon.Folders {
 				// For each folder in the addon we're removing
@@ -33,20 +33,20 @@ func uninstall(c *cli.Context) error {
 					dir := filepath.Join(addonDir, d)
 					err := os.RemoveAll(dir)
 					if err != nil {
-						fmt.Printf("%s: %s: failed to remove directory %s: %s\n", name, failed("failed"), dir, err.Error())
+						output.Printf("%s: %s: failed to remove directory %s: %s\n", name, failed("failed"), dir, err.Error())
 					} else {
-						fmt.Printf("%s: directory %s %s\n", name, d, success("removed"))
+						output.Printf("%s: directory %s %s\n", name, d, success("removed"))
 					}
 				} else {
-					fmt.Printf("%s: directory %s not removed, also used by %s\n", name, d, usedby)
+					output.Printf("%s: directory %s not removed, also used by %s\n", name, d, usedby)
 				}
 			}
 			delete(config.Addons, name)
 			err := writeConfig()
 			if err != nil {
-				fmt.Printf("%s: Failed to update configuration file %s: %s", failed("failed"), configFile, err.Error())
+				output.Printf("%s: Failed to update configuration file %s: %s", failed("failed"), configFile, err.Error())
 			} else {
-				fmt.Printf("%s: %s\n", name, success("uninstalled"))
+				output.Printf("%s: %s\n", name, success("uninstalled"))
 			}
 		}
 	}

--- a/update.go
+++ b/update.go
@@ -1,8 +1,7 @@
 package main
 
 import (
-	"fmt"
-
+	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
 )
 
@@ -24,23 +23,23 @@ func update(c *cli.Context) error {
 	for _, name := range addons {
 		addon, ok := config.Addons[name]
 		if !ok {
-			fmt.Printf("%s: isn't installed\n", failed(name))
+			output.Printf("%s: isn't installed\n", failed(name))
 			continue
 		}
 		if addon.Locked {
-			fmt.Printf("%s: locked, not updating\n", failed(name))
+			output.Printf("%s: locked, not updating\n", failed(name))
 			continue
 		}
 		meta, err := downloadURL(name, addon.Source)
 		if err != nil {
-			fmt.Printf("%s: failed to retrieve metadata: %s\n", failed(name), err.Error())
+			output.Printf("%s: failed to retrieve metadata: %s\n", failed(name), err.Error())
 			continue
 		}
 		if meta.Version == addon.Version {
 			if wowV != 0 && addon.Interface != 0 && addon.Interface < wowV {
-				fmt.Printf("%s: (out of date) no update from %s available\n", warn(name), addon.Version)
+				output.Printf("%s: (out of date) no update from %s available\n", warn(name), addon.Version)
 			} else {
-				fmt.Printf("%s: up to date at version %s\n", success(name), addon.Version)
+				output.Printf("%s: up to date at version %s\n", success(name), addon.Version)
 				continue
 			}
 		}
@@ -49,7 +48,7 @@ func update(c *cli.Context) error {
 			updated++
 		}
 	}
-	fmt.Printf("%d addons updated\n", updated)
+	output.Printf("%d addons updated\n", updated)
 	if !config.KeepCache {
 		purgeCache()
 	}
@@ -64,18 +63,18 @@ func checkupdate(c *cli.Context) error {
 		}
 		meta, err := downloadURL(name, addon.Source)
 		if err != nil {
-			fmt.Printf("%s: failed to retrieve metadata: %s\n", failed(name), err.Error())
+			output.Printf("%s: failed to retrieve metadata: %s\n", failed(name), err.Error())
 			continue
 		}
 		if meta.Version != addon.Version {
-			fmt.Printf("%s: can be updated from %s to %s\n", success(name), addon.Version, meta.Version)
+			output.Printf("%s: can be updated from %s to %s\n", success(name), addon.Version, meta.Version)
 			updated++
 		}
 	}
 	if updated > 0 {
-		fmt.Printf("%d addons can be updated\n", updated)
+		output.Printf("%d addons can be updated\n", updated)
 	} else {
-		fmt.Printf("%s\n", success("You have the latest version of everything"))
+		output.Printf("%s\n", success("You have the latest version of everything"))
 	}
 	return nil
 }

--- a/update.go
+++ b/update.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
+	"github.com/wttw/wowaddon/output"
 )
 
 func update(c *cli.Context) error {

--- a/wowaddon.go
+++ b/wowaddon.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/kardianos/osext"
+	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
 )
 
@@ -58,10 +59,6 @@ var config = Config{
 }
 
 func main() {
-	if err := EnableColor(); err != nil {
-		panic(err)
-	}
-
 	Version = fmt.Sprintf("%d.%d.%d", (numericVersion&0xff0000)>>16, (numericVersion&0xff00)>>8, numericVersion&0xff)
 	app := cli.NewApp()
 	app.Name = "wowaddon"
@@ -213,7 +210,7 @@ func main() {
 			Usage:  "display release tag",
 			Hidden: true,
 			Action: func(c *cli.Context) error {
-				fmt.Printf("%s\n", app.Version)
+				output.Printf("%s\n", app.Version)
 				return nil
 			},
 		},
@@ -255,20 +252,20 @@ func setup(c *cli.Context) error {
 		jsonParser := json.NewDecoder(cf)
 		err = jsonParser.Decode(&config)
 		if err != nil {
-			fmt.Printf("I couldn't parse configuration file '%s': %s\nMaybe fix it up, or delete it and start over?\n", configFile, err.Error())
+			output.Printf("I couldn't parse configuration file '%s': %s\nMaybe fix it up, or delete it and start over?\n", configFile, err.Error())
 			os.Exit(1)
 		}
 	} else {
-		fmt.Printf("Setting up your configuration...\n")
+		output.Printf("Setting up your configuration...\n")
 		err = bootstrapConfig()
 		if err != nil {
-			fmt.Printf("Failed to set up configuration: %s\n", err.Error())
+			output.Printf("Failed to set up configuration: %s\n", err.Error())
 		}
 	}
 
 	err = os.MkdirAll(cacheDir, 0755)
 	if err != nil {
-		fmt.Printf("Can't create directory '%s': %s\n", cacheDir, err.Error())
+		output.Printf("Can't create directory '%s': %s\n", cacheDir, err.Error())
 		os.Exit(1)
 	}
 

--- a/wowaddon.go
+++ b/wowaddon.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/kardianos/osext"
-	"github.com/pdbogen/wowaddon/output"
 	"github.com/urfave/cli"
+	"github.com/wttw/wowaddon/output"
 )
 
 const configFilename = "addons.json"


### PR DESCRIPTION
Howdy, Steve.

Unfortunately, our last attempt panics on Windows 8- it seems that the fancy terminal mode is only available on Windows 10.

I've removed that code and replaced it with the use of github.com/mattn/go-colorable, which is required / recommended by github.com/fatih/color.

This is working for me on both windows 8 and windows 10, and providing colored output for both. 